### PR TITLE
CircleCIの導入

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ jobs:
     - APP_ENV: testing
     - APP_KEY: base64:zsfVVlJri1egk8O9a1sFS/sVuqCqEerGcUwD2FH1O8s=
     - DB_CONNECTION: mysql
+    - DB_USERNAME: root
+    - DB_PASSWORD: ''
     - MYSQL_ALLOW_EMPTY_PASSWORD: true
 
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,68 @@
+# PHP CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-php/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+    # Specify the version you desire here
+    - image: circleci/php:7.1-jessie-node-browsers
+
+    # Specify service dependencies here if necessary
+    # CircleCI maintains a library of pre-built images
+    # documented at https://circleci.com/docs/2.0/circleci-images/
+    # Using the RAM variation mitigates I/O contention
+    # for database intensive operations.
+    # - image: circleci/mysql:5.7-ram
+    #
+    # - image: redis:2.8.19
+
+    steps:
+    - checkout
+
+    - run: sudo apt update && sudo apt install zlib1g-dev libsqlite3-dev
+    - run: sudo docker-php-ext-install zip
+
+    # Download and cache dependencies
+
+    # composer cache
+    - restore_cache:
+        keys:
+        # "composer.lock" can be used if it is committed to the repo
+        - v1-dependencies-{{ checksum "composer.json" }}
+        # fallback to using the latest cache if no exact match is found
+        - v1-dependencies-
+
+    - run: composer install -n --prefer-dist
+
+    - save_cache:
+        key: composer-v1-{{ checksum "composer.lock" }}
+        paths:
+        - vendor
+
+    # node cache
+
+    - restore_cache:
+        keys:
+        - node-v3-{{ checksum "package.json" }}
+        - node-v3-
+    - run: yarn install
+    - save_cache:
+        key: node-v3-{{ checksum "package.json" }}
+        paths:
+        - node_modules
+        - ~/.yarn
+
+    # prepare the database
+    - run: touch storage/testing.sqlite
+    - run: php artisan migrate --env=testing --database=sqlite_testing --force
+
+    # run tests with phpunit or codecept
+    #- run: ./vendor/bin/phpunit
+    - run: ./vendor/bin/codecept build
+    - run: ./vendor/bin/codecept run --xml result.xml
+    - store_test_results:
+        path: tests/_output
+    - store_artifacts:
+        path: tests/_output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,10 +69,4 @@ jobs:
     - run: php artisan db:seed
 
     # run tests with phpunit or codecept
-    #- run: ./vendor/bin/phpunit
-    - run: ./vendor/bin/codecept build
-    - run: ./vendor/bin/codecept run --xml result.xml
-    - store_test_results:
-        path: tests/_output
-    - store_artifacts:
-        path: tests/_output
+    - run: ./vendor/bin/phpunit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
     # Specify the version you desire here
-    - image: circleci/php:7.2-jessie-node-browsers
+    - image: circleci/php:7.2.1-apache-node-browsers
     - image: circleci/mysql:5.7
 
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
     # Specify the version you desire here
-    - image: circleci/php:7.2.1-apache-node-browsers
+    - image: circleci/php:7.2.11-apache-node-browsers-legacy
     - image: circleci/mysql:5.7
 
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,17 @@ jobs:
   build:
     docker:
     # Specify the version you desire here
-    - image: circleci/php:7.1-jessie-node-browsers
+    - image: circleci/php:7.2-jessie-node-browsers
+    - image: circleci/mysql:5.7
+
+    environment:
+    - APP_DEBUG: true
+    - APP_ENV: testing
+    - APP_KEY: base64:zsfVVlJri1egk8O9a1sFS/sVuqCqEerGcUwD2FH1O8s=
+    - DB_CONNECTION: mysql
+    - MYSQL_ALLOW_EMPTY_PASSWORD: true
+
+    working_directory: ~/repo
 
     # Specify service dependencies here if necessary
     # CircleCI maintains a library of pre-built images
@@ -22,7 +32,7 @@ jobs:
     - checkout
 
     - run: sudo apt update && sudo apt install zlib1g-dev libsqlite3-dev
-    - run: sudo docker-php-ext-install zip
+    - run: sudo docker-php-ext-install zip pdo_mysql
 
     # Download and cache dependencies
 
@@ -55,8 +65,8 @@ jobs:
         - ~/.yarn
 
     # prepare the database
-    - run: touch storage/testing.sqlite
-    - run: php artisan migrate --env=testing --database=sqlite_testing --force
+    - run: php artisan migrate
+    - run: php artisan db:seed
 
     # run tests with phpunit or codecept
     #- run: ./vendor/bin/phpunit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,7 @@ jobs:
     - APP_DEBUG: true
     - APP_ENV: testing
     - APP_KEY: base64:zsfVVlJri1egk8O9a1sFS/sVuqCqEerGcUwD2FH1O8s=
-    - DB_CONNECTION: mysql
-    - DB_USERNAME: root
-    - DB_PASSWORD: ''
+    - DB_CONNECTION: circle_test
     - MYSQL_ALLOW_EMPTY_PASSWORD: true
 
     working_directory: ~/repo

--- a/config/database.php
+++ b/config/database.php
@@ -39,6 +39,20 @@ return [
             'prefix' => '',
         ],
 
+        'circle_test' => [
+            'driver' => 'mysql',
+            'host' => '127.0.0.1',
+            'port' => '3306',
+            'database' => 'circle_test',
+            'username' => 'root',
+            'password' => '',
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'strict' => true,
+            'engine' => null,
+        ],
+
         'mysql' => [
             'driver' => 'mysql',
             'host' => env('DB_HOST', '127.0.0.1'),


### PR DESCRIPTION
# ベースにした設定ファイル
- [circleci-demo-php-laravel](https://github.com/CircleCI-Public/circleci-demo-php-laravel/blob/circleci-2.0/.circleci/config.yml)をベースにした

# DBの設定で参考にした
- [CircleCI2.0でMySQLを使ったLaravelのテストを実行する](https://qiita.com/kazuhei/items/29ee2c3cbd5960814959)

# dockerイメージに関して
- [circleci/mysql](https://hub.docker.com/r/circleci/mysql/)に環境情報などはすでに設定済み
- [circleci/php](https://hub.docker.com/r/circleci/php/tags/)この中から選択